### PR TITLE
Add utf-8 charset to calculatePrefix method.

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function checkMimeType(paths) {
 }
 
 function calculatePrefix(mimeType) {
-  return `data:${mimeType};base64,`;
+  return `data:${mimeType};charset=utf-8;base64,`;
 }
 
 function fetchLocal(...paths) {


### PR DESCRIPTION
Hi, gamell. Thanks for this nice pithy module. I found myself wanting to use data[1] but noticed that charset was missing. You might have done that on purpose, and it might not make much difference, but I found myself wishing it were there. Easy enough to add and doesn't seem to break anything. 

My 2-cents.

Thanks again!