### PR TITLE
Custom headers fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,8 +6,7 @@ const local = require('./lib/fetch-local.js');
 let api = {};
 let headers = {};
 
-function checkMimeType(paths) {
-  const path = (Array.isArray(paths)) ? paths[paths.length - 1] : paths;
+function checkMimeType(path) {
   const promise = new Promise((resolve, reject) => {
     try {
       resolve(mime.lookup(path));
@@ -22,21 +21,21 @@ function calculatePrefix(mimeType) {
   return `data:${mimeType};base64,`;
 }
 
-function fetchLocal(...paths) {
-  return checkMimeType(paths)
+function fetchLocal(path) {
+  return checkMimeType(path)
     .then(mimeType => calculatePrefix(mimeType))
-    .then(prefix => local.fetch(...paths).then(base64 => [base64, prefix + base64]));
+    .then(prefix => local.fetch(path).then(base64 => [base64, prefix + base64]))
 }
 
-function fetchRemote(...paths) {
-  return checkMimeType(paths)
+function fetchRemote(path, headers) {
+  return checkMimeType(path)
     .then(mimeType => calculatePrefix(mimeType))
-    .then(prefix => remote.fetch({ paths, headers }).then(base64 => [base64, prefix + base64]));
+    .then(prefix => remote.fetch(path, headers).then(base64 => [base64, prefix + base64]))
 }
 
-function auto(...paths) {
+function auto(path, headers) {
   try {
-    return (uriMatcher.isRemote(paths[0])) ? fetchRemote(...paths) : fetchLocal(...paths);
+    return (uriMatcher.isRemote(path)) ? fetchRemote(path, headers) : fetchLocal(path);
   } catch (e) {
     return Promise.reject(e);
   }

--- a/lib/fetch-remote.js
+++ b/lib/fetch-remote.js
@@ -1,5 +1,4 @@
 const { URL } = require('url');
-const legacyUrl = require('url');
 const http = require('http');
 const https = require('https');
 

--- a/lib/fetch-remote.js
+++ b/lib/fetch-remote.js
@@ -6,22 +6,25 @@ const https = require('https');
 const ua = 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36';
 
 module.exports = {
-  fetch: ({ paths, headers = {} }) => {
+  fetch: (uri, headers = {}) => {
     const promise = new Promise((resolve, reject) => {
-      const uri = (paths.length > 1) ? legacyUrl.resolve(...paths) : paths[0];
       let myUrl;
       try {
         myUrl = new URL(uri);
       } catch (e) {
         reject(`URL Parse error: ${e}`);
       }
-      myUrl.method = 'GET'; // add http method
-      myUrl.headers = { // Spoof user agent by default
-        'User-Agent': ua,
-        ...headers
+      const agentOptions = {
+        hostname: myUrl.host,
+        path: myUrl.pathname + myUrl.search + myUrl.hash,
+        method: 'GET',
+        headers: {
+          'User-Agent': ua,
+          ...headers,
+        }
       };
       const agent = (myUrl.protocol === 'https:') ? https : http;
-      const req = agent.request(myUrl, (res) => {
+      const req = agent.request(agentOptions, (res) => {
         if (res.statusCode !== 200) {
           reject(`Status code ${res.statusCode} returned when trying to fetch file`);
           return false;


### PR DESCRIPTION
Hi,
I have properly implemented the headers feature as neither the original implementation nor the new branch was sending any headers to the server (not even the User-Agent).
I didnt modified any of the tests as im not familiar with that part but i have fully tested (successfully capturing the headers on a php server I control) and implemented on one of the node projects of my company which i had to retreive base64 images using the header {'Authentication': 'Bearer'+ JWT'}.
I also removed the feature of having multiple "paths" for a same request as i think the component should only resolve one path at a time and then the user do whatever needs for each individual project.
This has been also caused because rest parameter "...path" as a first parameter (having a second parameter -in this case 'headers-) of fetchRemote is not allowed. So now is just "path" all across the component.
The problem with the headers not being sent was passing 'myUrl' object to agent.request(), so using a simple object as shown in [the node documentation](https://nodejs.org/api/http.html#http_event_connect) does send the headers now.